### PR TITLE
feat(api): add prometheus and grafana

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+    -   id: check-merge-conflict
+
+-   repo: local
+    hooks:
+    -   id: poetry-check
+        name: Check if Poetry lock file is up to date
+        entry: bash -c 'poetry check && poetry lock'
+        language: system
+        pass_filenames: false
+        files: ^pyproject\.toml$
+
+    -   id: lint
+        name: Run linting checks
+        entry: bash -c 'make lint'
+        language: system
+        pass_filenames: false
+        types: [python]

--- a/babeltron/app/monitoring.py
+++ b/babeltron/app/monitoring.py
@@ -1,0 +1,173 @@
+import time
+
+from fastapi import Request
+from prometheus_client import CollectorRegistry, Counter, Histogram, generate_latest
+from starlette.middleware.base import BaseHTTPMiddleware
+
+# Create a registry
+registry = CollectorRegistry()
+
+# Define metrics
+REQUEST_COUNT = Counter(
+    "http_requests_total",
+    "Total count of HTTP requests",
+    ["method", "endpoint", "status_code"],
+    registry=registry,
+)
+
+REQUEST_LATENCY = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request latency in seconds",
+    ["method", "endpoint"],
+    buckets=(
+        0.01,
+        0.025,
+        0.05,
+        0.075,
+        0.1,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        2.5,
+        5.0,
+        7.5,
+        10.0,
+        25.0,
+        50.0,
+    ),
+    registry=registry,
+)
+
+ERROR_COUNT = Counter(
+    "http_request_errors_total",
+    "Total count of HTTP request errors",
+    ["method", "endpoint", "exception_type"],
+    registry=registry,
+)
+
+TRANSLATION_COUNT = Counter(
+    "translation_requests_total",
+    "Total count of translation requests",
+    ["src_lang", "tgt_lang"],
+    registry=registry,
+)
+
+TRANSLATION_LATENCY = Histogram(
+    "translation_duration_seconds",
+    "Translation processing time in seconds",
+    ["src_lang", "tgt_lang"],
+    buckets=(
+        0.05,
+        0.1,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        1.5,
+        2.0,
+        2.5,
+        3.0,
+        3.5,
+        4,
+        4.5,
+        5.0,
+        7.5,
+        10.0,
+        15.0,
+        20.0,
+        30.0,
+        60.0,
+    ),
+    registry=registry,
+)
+
+CACHE_HIT_COUNT = Counter(
+    "cache_hits_total", "Total count of cache hits", ["endpoint"], registry=registry
+)
+
+CACHE_MISS_COUNT = Counter(
+    "cache_misses_total", "Total count of cache misses", ["endpoint"], registry=registry
+)
+
+MODEL_LOAD_TIME = Histogram(
+    "model_load_time_seconds",
+    "Time taken to load the model",
+    ["model_size"],
+    buckets=(0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0),
+    registry=registry,
+)
+
+
+class PrometheusMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app=None):
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next):
+        start_time = time.time()
+
+        # Get the route path for the request
+        route = request.url.path
+        method = request.method
+
+        try:
+            response = await call_next(request)
+
+            # Record request count and latency
+            REQUEST_COUNT.labels(
+                method=method, endpoint=route, status_code=response.status_code
+            ).inc()
+            REQUEST_LATENCY.labels(method=method, endpoint=route).observe(
+                time.time() - start_time
+            )
+
+            # Record error if status code is 4xx or 5xx
+            if 400 <= response.status_code < 600:
+                ERROR_COUNT.labels(
+                    method=method,
+                    endpoint=route,
+                    exception_type=f"HTTP{response.status_code}",
+                ).inc()
+
+            return response
+
+        except Exception as e:
+            # Record exception
+            ERROR_COUNT.labels(
+                method=method, endpoint=route, exception_type=type(e).__name__
+            ).inc()
+            raise
+
+
+def track_dynamic_translation_metrics():
+    def decorator(func):
+        from functools import wraps
+
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            request = kwargs.get("request")
+            if not request and args:
+                request = args[0]
+
+            start_time = time.time()
+            src_lang = request.src_lang
+            tgt_lang = request.tgt_lang
+
+            TRANSLATION_COUNT.labels(src_lang=src_lang, tgt_lang=tgt_lang).inc()
+
+            result = await func(*args, **kwargs)
+
+            TRANSLATION_LATENCY.labels(src_lang=src_lang, tgt_lang=tgt_lang).observe(
+                time.time() - start_time
+            )
+
+            return result
+
+        return wrapper
+
+    return decorator
+
+
+def metrics_endpoint():
+    """Generate latest metrics in Prometheus format"""
+    return generate_latest(registry)

--- a/babeltron/app/routers/translate.py
+++ b/babeltron/app/routers/translate.py
@@ -6,6 +6,7 @@ from fastapi_cache.decorator import cache
 from pydantic import BaseModel, Field
 from transformers import M2M100ForConditionalGeneration, M2M100Tokenizer
 
+from babeltron.app.monitoring import track_dynamic_translation_metrics
 from babeltron.app.utils import ORJsonCoder, cache_key_builder, get_model_path
 
 router = APIRouter(tags=["Translation"])
@@ -77,6 +78,7 @@ class TranslationResponse(BaseModel):
     status_code=status.HTTP_200_OK,
 )
 @cache(expire=CACHE_TTL_SECONDS, key_builder=cache_key_builder, coder=ORJsonCoder)
+@track_dynamic_translation_metrics()
 async def translate(request: TranslationRequest):
     if model is None or tokenizer is None:
         raise HTTPException(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     environment:
       - MODEL_PATH=/models
       - CACHE_URL=in-memory
+      - METRICS_ENABLED=true
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/healthz"]
@@ -19,3 +20,34 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+    depends_on:
+      - api
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-storage:/var/lib/grafana
+    depends_on:
+      - prometheus
+
+volumes:
+  grafana-storage:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing
+
+We welcome contributions to Babeltron! This document provides guidelines for setting up your development environment and ensuring code quality.
+
+## Development Setup
+
+1. Clone the repository:
+```bash
+git clone https://github.com/hspedro/babeltron.git
+cd babeltron
+```
+
+2. Install dependencies:
+```bash
+make install
+```
+
+3. Install pre-commit hooks:
+```bash
+make pre-commit-install
+```
+
+## Pre-commit Hooks
+
+Babeltron uses pre-commit hooks to ensure code quality and consistency. These hooks run automatically when you commit changes and check for:
+
+- Outdated Poetry lock files
+- Linting issues
+- Trailing whitespace and file formatting issues
+- YAML syntax errors
+- Merge conflicts
+
+To run the pre-commit hooks manually on all files:
+
+```bash
+pre-commit run --all-files
+```
+
+## Code Style
+
+Babeltron follows these code style guidelines:
+
+- [Black](https://github.com/psf/black) for code formatting
+- [isort](https://pycqa.github.io/isort/) for import sorting
+
+You can run these checks manually with:
+
+```bash
+make lint
+```
+
+## Testing
+
+Before submitting a pull request, make sure all tests pass:
+
+```bash
+make test
+```
+
+To run tests with coverage reporting:
+
+```bash
+make coverage
+```
+
+## Pull Request Process
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Make your changes
+4. Run tests and linting checks
+5. Commit your changes (`git commit -m 'Add amazing feature'`)
+6. Push to the branch (`git push origin feature/amazing-feature`)
+7. Open a Pull Request
+
+## Running locally
+
+```bash
+make serve
+```
+
+Will mostly do the trick since it has auto-reload.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1360,6 +1360,21 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "prometheus-client"
+version = "0.21.1"
+description = "Python client for the Prometheus monitoring system."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "prometheus_client-0.21.1-py3-none-any.whl", hash = "sha256:594b45c410d6f4f8888940fe80b5cc2521b305a1fafe1c58609ef715a001f301"},
+    {file = "prometheus_client-0.21.1.tar.gz", hash = "sha256:252505a722ac04b0456be05c05f75f45d760c2911ffc45f2a06bcaed9f3ae3fb"},
+]
+
+[package.extras]
+twisted = ["twisted"]
+
+[[package]]
 name = "protobuf"
 version = "5.29.3"
 description = ""
@@ -1913,6 +1928,22 @@ typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart", "pyyaml"]
 
 [[package]]
+name = "starlette-prometheus"
+version = "0.10.0"
+description = "Prometheus integration for Starlette"
+optional = false
+python-versions = "<4.0,>=3.8"
+groups = ["main"]
+files = [
+    {file = "starlette_prometheus-0.10.0-py3-none-any.whl", hash = "sha256:8b2f997495f809f01387378dad5476b2a1cf2fb2d9b96164394effdecb2d8380"},
+    {file = "starlette_prometheus-0.10.0.tar.gz", hash = "sha256:77d1e9cfad572206e8de242975bd00a62e33685eb330389f2add04e4d719d47d"},
+]
+
+[package.dependencies]
+prometheus_client = ">=0.12"
+starlette = ">=0.12.2"
+
+[[package]]
 name = "sympy"
 version = "1.13.1"
 description = "Computer algebra system (CAS) in Python"
@@ -2241,4 +2272,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.5.0)
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "b5ed6aae057b8eee1cf741e6215413a44263121cfd98da66a42101a002da3f04"
+content-hash = "f7cea064076a0ffe8ebaa459aab85ce786f1b63fdc02da4d45671ae4bad6cea8"

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'babeltron'
+    static_configs:
+      - targets: ['api:8000']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ uvicorn = "^0.22.0"
 fastapi-cache2 = "^0.2.2"
 redis = "^5.2.1"
 orjson = "^3.10.15"
+prometheus-client = "^0.21.1"
+starlette-prometheus = "^0.10.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.0"

--- a/recovered_download_models.py
+++ b/recovered_download_models.py
@@ -1,0 +1,8 @@
+# uncompyle6 version 3.9.2
+# Python bytecode version base 3.12.0 (3531)
+# Decompiled from: Python 3.12.9 | packaged by Anaconda, Inc. | (main, Feb  6 2025, 12:55:12) [Clang 14.0.6 ]
+# Embedded file name: /Users/hspedro/Projects/babeltron/babeltron/scripts/download_models.py
+# Compiled at: 2025-03-05 13:06:05
+# Size of source mod 2**32: 2903 bytes
+
+Unsupported Python version, 3.12.0, for decompilation

--- a/tests/unit/app/test_main.py
+++ b/tests/unit/app/test_main.py
@@ -37,6 +37,18 @@ class TestMainApp:
         async with lifespan(mock_app):
             pass
 
+        # No cache URL should not initialize any cache
+        mock_init.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch.object(FastAPICache, "init")
+    @patch.dict("os.environ", {"CACHE_URL": "in-memory"})
+    async def test_lifespan_with_inmemory_cache_url(self, mock_init):
+        mock_app = MagicMock()
+
+        async with lifespan(mock_app):
+            pass
+
         mock_init.assert_called_once()
         args, kwargs = mock_init.call_args
         assert isinstance(args[0], InMemoryBackend)

--- a/tests/unit/app/test_monitoring.py
+++ b/tests/unit/app/test_monitoring.py
@@ -1,0 +1,139 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import Request, Response
+from prometheus_client import Counter, Histogram
+from babeltron.app.monitoring import (
+    CACHE_HIT_COUNT,
+    CACHE_MISS_COUNT,
+    ERROR_COUNT,
+    MODEL_LOAD_TIME,
+    REQUEST_COUNT,
+    REQUEST_LATENCY,
+    TRANSLATION_COUNT,
+    TRANSLATION_LATENCY,
+    PrometheusMiddleware,
+    metrics_endpoint,
+    track_dynamic_translation_metrics,
+)
+
+
+class TestMonitoring:
+    @pytest.fixture
+    def mock_request(self):
+        request = MagicMock(spec=Request)
+        request.url.path = "/test/path"
+        request.method = "GET"
+        return request
+
+    @pytest.fixture
+    def mock_response(self):
+        response = MagicMock(spec=Response)
+        response.status_code = 200
+        return response
+
+    @pytest.fixture
+    def mock_error_response(self):
+        response = MagicMock(spec=Response)
+        response.status_code = 500
+        return response
+
+    @pytest.mark.asyncio
+    async def test_prometheus_middleware_success(self, mock_request, mock_response):
+        middleware = PrometheusMiddleware(None)
+        call_next = AsyncMock(return_value=mock_response)
+
+        response = await middleware.dispatch(mock_request, call_next)
+
+        assert response == mock_response
+        call_next.assert_called_once_with(mock_request)
+        # Check that metrics were recorded
+
+    @pytest.mark.asyncio
+    async def test_prometheus_middleware_error_status(self, mock_request, mock_error_response):
+        middleware = PrometheusMiddleware(None)
+        call_next = AsyncMock(return_value=mock_error_response)
+
+        response = await middleware.dispatch(mock_request, call_next)
+
+        assert response == mock_error_response
+        call_next.assert_called_once_with(mock_request)
+        # Check that error metrics were recorded
+
+    @pytest.mark.asyncio
+    async def test_prometheus_middleware_exception(self, mock_request):
+        middleware = PrometheusMiddleware(None)
+        exception = ValueError("Test exception")
+        call_next = AsyncMock(side_effect=exception)
+
+        with pytest.raises(ValueError):
+            await middleware.dispatch(mock_request, call_next)
+
+        call_next.assert_called_once_with(mock_request)
+        # Check that exception metrics were recorded
+
+    @pytest.mark.asyncio
+    async def test_track_dynamic_translation_metrics_with_request_arg(self):
+        # Test with request as first positional argument
+        mock_request = MagicMock()
+        mock_request.src_lang = "en"
+        mock_request.tgt_lang = "fr"
+
+        @track_dynamic_translation_metrics()
+        async def test_func(request):
+            return "result"
+
+        result = await test_func(mock_request)
+
+        assert result == "result"
+        # Check that translation metrics were recorded
+
+    @pytest.mark.asyncio
+    async def test_track_dynamic_translation_metrics_with_request_kwarg(self):
+        # Test with request as keyword argument
+        mock_request = MagicMock()
+        mock_request.src_lang = "en"
+        mock_request.tgt_lang = "fr"
+
+        @track_dynamic_translation_metrics()
+        async def test_func(some_arg, request=None):
+            return "result"
+
+        result = await test_func("some_value", request=mock_request)
+
+        assert result == "result"
+        # Check that translation metrics were recorded
+
+    def test_metrics_endpoint(self):
+        result = metrics_endpoint()
+        assert isinstance(result, bytes)
+        # The result should be a byte string of Prometheus metrics
+
+    def test_registry_metrics(self):
+        # Test that all metrics are properly registered
+        assert isinstance(REQUEST_COUNT, Counter)
+        assert isinstance(REQUEST_LATENCY, Histogram)
+        assert isinstance(ERROR_COUNT, Counter)
+        assert isinstance(TRANSLATION_COUNT, Counter)
+        assert isinstance(TRANSLATION_LATENCY, Histogram)
+        assert isinstance(CACHE_HIT_COUNT, Counter)
+        assert isinstance(CACHE_MISS_COUNT, Counter)
+        assert isinstance(MODEL_LOAD_TIME, Histogram)
+
+    @patch('time.time')
+    def test_translation_latency_observe(self, mock_time):
+        # Test that translation latency is observed correctly
+        mock_time.side_effect = [100.0, 105.0]  # Start time, end time
+
+        with TRANSLATION_LATENCY.labels(src_lang="en", tgt_lang="fr").time():
+            pass
+
+        # The time difference should be 5.0 seconds
+        # This is implicitly tested by the context manager
+
+    def test_translation_count_inc(self):
+        # Test that translation count is incremented correctly
+        before = TRANSLATION_COUNT.labels(src_lang="en", tgt_lang="fr")._value.get()
+        TRANSLATION_COUNT.labels(src_lang="en", tgt_lang="fr").inc()
+        after = TRANSLATION_COUNT.labels(src_lang="en", tgt_lang="fr")._value.get()
+        assert after == before + 1


### PR DESCRIPTION
* docs: add contribution instructions
* chore: add pre-commit linting and checking poetry
* feat(api): add prometheus and grafana

There is a decorator to translate API that emits metrics of /translate request count and response time that tags source and destination language