### PR TITLE
chore: remove support to py 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     uses: ./.github/workflows/test.yml
     with:
       python-version: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "babeltron"
-version = "0.6.0"
+version = "0.7.1"
 dynamic = ["version"]
 description = "A Python-based REST API that leverages single multilingual models like mBERT to provide efficient text translation services"
 authors = [


### PR DESCRIPTION
Due to lingua not having wheels for 3.13 yet, the project can not build to 3.13, thus removing it