### PR TITLE
Feat/language mapping

### DIFF
--- a/babeltron/app/models/translation/nllb.py
+++ b/babeltron/app/models/translation/nllb.py
@@ -239,11 +239,16 @@ class NLLBTranslationModel(TranslationModelBase):
             "en": "eng_Latn",
             "fr": "fra_Latn",
             "es": "spa_Latn",
+            "es-419": "spa_Latn",
             "de": "deu_Latn",
             "zh": "zho_Hans",
+            "zh-cn": "zho_Hans",
+            "zh-tw": "zho_Hant",
             "ar": "ara_Arab",
             "ru": "rus_Cyrl",
             "pt": "por_Latn",
+            "pt-br": "por_Latn",
+            "pt-pt": "por_Latn",
             "it": "ita_Latn",
             "ja": "jpn_Jpan",
             "ko": "kor_Hang",
@@ -311,6 +316,7 @@ class NLLBTranslationModel(TranslationModelBase):
             return lang_code
 
         # If we have a mapping, use it
+        lang_code = lang_code.lower()
         if lang_code in iso_to_nllb:
             return iso_to_nllb[lang_code]
 

--- a/tests/unit/app/routers/test_detect.py
+++ b/tests/unit/app/routers/test_detect.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from fastapi import status
 from fastapi.testclient import TestClient
 
@@ -83,3 +83,96 @@ def test_detect_invalid_request(client):
         json={},  # Missing required field 'text'
     )
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@patch("babeltron.app.models.detection.factory.get_detection_model")
+@patch("babeltron.app.routers.detect.detection_model", new_callable=MagicMock)
+def test_detect_with_cache_disabled(mock_detection_model, mock_get_model, client):
+    # Create a mock model
+    mock_model = MagicMock()
+    mock_model.is_loaded = True
+    mock_model.architecture = "lingua"
+    mock_model.detect.return_value = ("fr", 0.95)
+
+    # Make the factory return our mock model
+    mock_get_model.return_value = mock_model
+
+    # Configure the detection_model mock
+    mock_detection_model.is_loaded = True
+    mock_detection_model.architecture = "lingua"
+    mock_detection_model.detect.return_value = ("fr", 0.95)
+
+    # Test data with cache disabled
+    test_data = {
+        "text": "Bonjour, comment ça va?",
+        "cache": False
+    }
+
+    # Mock the cache service to return a cached result
+    with patch("babeltron.app.routers.detect.cache_service") as mock_cache:
+        mock_cache.get_detection.return_value = {
+            "language": "en",
+            "confidence": 0.98,
+            "cached": True
+        }
+
+        response = client.post("/api/v1/detect", json=test_data)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["language"] == "fr"  # Should use fresh detection, not cached
+        assert data["confidence"] == 0.95
+        assert data["cached"] is False
+
+        # Verify the model was called correctly
+        mock_detection_model.detect.assert_called_once()
+        args, kwargs = mock_detection_model.detect.call_args
+        assert args[0] == "Bonjour, comment ça va?"
+
+        # Verify cache was not used
+        mock_cache.get_detection.assert_not_called()
+        mock_cache.save_detection.assert_not_called()
+
+
+@patch("babeltron.app.models.detection.factory.get_detection_model")
+@patch("babeltron.app.routers.detect.detection_model", new_callable=MagicMock)
+def test_detect_with_cache_enabled(mock_detection_model, mock_get_model, client):
+    # Create a mock model
+    mock_model = MagicMock()
+    mock_model.is_loaded = True
+    mock_model.architecture = "lingua"
+    mock_model.detect.return_value = ("fr", 0.95)
+
+    # Make the factory return our mock model
+    mock_get_model.return_value = mock_model
+
+    # Configure the detection_model mock
+    mock_detection_model.is_loaded = True
+    mock_detection_model.architecture = "lingua"
+    mock_detection_model.detect.return_value = ("fr", 0.95)
+
+    # Test data with cache enabled (default)
+    test_data = {
+        "text": "Bonjour, comment ça va?"
+    }
+
+    # Mock the cache service to return a cached result
+    with patch("babeltron.app.routers.detect.cache_service") as mock_cache:
+        mock_cache.get_detection.return_value = {
+            "language": "en",
+            "confidence": 0.98,
+            "cached": True
+        }
+
+        response = client.post("/api/v1/detect", json=test_data)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["language"] == "en"  # Should use cached result
+        assert data["confidence"] == 0.98
+        assert data["cached"] is True
+
+        # Verify the model was not called (using cached result)
+        mock_detection_model.detect.assert_not_called()
+
+        # Verify cache was used
+        mock_cache.get_detection.assert_called_once()
+        mock_cache.save_detection.assert_not_called()  # Should not save since we used cached result


### PR DESCRIPTION
refactor(detect): add cache skipping param

commit b06ad38e5284e770d3a2cc5eeb63e12a4f4886c2
Author: Pedro Soares <pedro.soares@wildlifestudios.com>
Date:   Wed Mar 26 17:07:14 2025 -0300

    refactor(translate) cache query param

    The query param 'cache' controls whether or not to
    save predictions on cache or get cached results. By
    default it's always set to True, unless on request we
    see ?cache=false

commit e1b350a671cf01100f2905103c45fcef1fa94e66
Author: Pedro Soares <pedro.soares@wildlifestudios.com>
Date:   Wed Mar 26 17:05:32 2025 -0300

    feat(nllb): normalize language codes

    When mapping, convert to lower prior to checking in the
    language map